### PR TITLE
Add monitoring_stack/inventory.ini to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log
 # OS
 .DS_Store
 Thumbs.db 
+monitoring_stack/inventory.ini


### PR DESCRIPTION
- Updated .gitignore to include monitoring_stack/inventory.ini to prevent tracking of inventory files in version control.